### PR TITLE
Remove trailing period from url

### DIFF
--- a/src/youte/__main__.py
+++ b/src/youte/__main__.py
@@ -229,7 +229,7 @@ def add_key():
     )
     click.echo()
     click.echo("To obtain an API key, follow the steps in")
-    click.echo("https://developers.google.com/youtube/v3/getting-started.")
+    click.echo("https://developers.google.com/youtube/v3/getting-started")
     click.echo()
     click.echo(
         "Once you have an API key, run `youte configure add-key` to start.")


### PR DESCRIPTION
Removing trailing period from API key tutorial URL to prevent 404 upon clicking the link.
Updating from:
`To obtain an API key, follow the steps in https://developers.google.com/youtube/v3/getting-started.`
to:
`To obtain an API key, follow the steps in https://developers.google.com/youtube/v3/getting-started`